### PR TITLE
deps: migrate container images from Bitnami to Soldevelo equivalents

### DIFF
--- a/playbooks/portainer/docker-compose.yml
+++ b/playbooks/portainer/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       POSTGRES_PASSWORD: "password"
 
   redis:
-    image: bitnami/redis:7.0
+    image: soldevelo/redis:7.0
     restart: unless-stopped
     healthcheck:
       test: "redis-cli ping"


### PR DESCRIPTION
## Dependency update: Bitnami to SolDevelo container images

Bitnami changed its container image distribution model on **August 28, 2025**, restricting access to many previously free images.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides free drop-in replacement images built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a maintained fork of `bitnami/containers`, published to Docker Hub under the `soldevelo/` namespace. Tags are kept in sync with upstream Bitnami.

This PR updates all affected image references in the repository.

## Changed images

- `bitnami/redis:7.0` → [`soldevelo/redis:7.0`](https://hub.docker.com/r/soldevelo/redis)